### PR TITLE
Creating title object before Ext does so we can customize values

### DIFF
--- a/classic/src/MessageBox.js
+++ b/classic/src/MessageBox.js
@@ -25,6 +25,18 @@ Ext.define('Zan.common.MessageBox', {
             if ('yes' === buttonId) deferred.resolve(true);
         });
 
+        // This title object will be created anyways in the Msgbox.confirm() method if title is a string.
+        // We are creating it here so we can customize fields like the buttons and defaultFocus
+        title = {
+            title: title,
+            icon: Ext.Msg.QUESTION,
+            message: message,
+            buttons: Ext.Msg.YESNO,
+            defaultFocus: '#no',
+            callback: resolverCb,
+            scope: callbackFnScope
+        };
+
         Ext.MessageBox.confirm(title, message, resolverCb, callbackFnScope);
 
         return deferred.promise;


### PR DESCRIPTION
We wanted to set the default highlighted button to "No." Had to create this object before Ext did in order to change those values.